### PR TITLE
fix(mkrootfs&mkimg): fix argument parser

### DIFF
--- a/mkimg
+++ b/mkimg
@@ -10,6 +10,7 @@ colorize
 verbose=0
 use_fixed_password=0
 varbose_arg=
+rootfs="archriscv-$(date --rfc-3339=date).tar.zst"
 
 show_help() {
 cat << EOF
@@ -43,7 +44,7 @@ parse-args() {
             ;;
         p)  password=$OPTARG
             ;;
-        r)  rootfs=${OPTARG:-archriscv-$(date --rfc-3339=date).tar.zst}
+        r)  rootfs=$OPTARG
             ;;
         *)
             show_help >&2

--- a/mkrootfs
+++ b/mkrootfs
@@ -9,6 +9,7 @@ colorize
 
 verbose=0
 varbose_arg=
+password='archriscv'
 
 show_help() {
 cat << EOF
@@ -36,7 +37,7 @@ parse-args() {
         v)  verbose=$((verbose+1))
             varbose_arg="--verbose"
             ;;
-        p)  password=${OPTARG:-archriscv}
+        p)  password=$OPTARG
             ;;
         *)
             show_help >&2


### PR DESCRIPTION
The original `${var:-default}` form will not create variable if user doesn't attach any argument to the script.

For example, `./mkrootfs` will not create password variable, so when the succeeding script trying to read password from `$password` variable, they will only get blank string.

This PR create variable and assign default value at the beginning of the script. Those variable will be override when user specify argument to them.

Signed-off-by: Avimitin <avimitin@gmail.com>