### PR TITLE
feat: Enable networking and use systemd-nspawn instead of arch-chroot

### DIFF
--- a/mkimg
+++ b/mkimg
@@ -59,7 +59,7 @@ parse-args() {
 toggle-systemd-firstboot() {
     msg2 "Toggle systemd-firstboot..."
     sudo rm -f qcow2/etc/{machine-id,hostname,shadow}
-    sudo arch-chroot qcow2 systemctl enable systemd-firstboot.service
+    sudo systemd-nspawn -D qcow2 systemctl enable systemd-firstboot.service
 }
 
 use-fixed-password() {
@@ -132,7 +132,7 @@ popd
 
 msg "Install kernel package..."
 
-sudo arch-chroot qcow2 pacman \
+sudo systemd-nspawn -D qcow2 pacman \
     --noconfirm \
     -Syu linux linux-firmware
 
@@ -148,6 +148,15 @@ label linux
     initrd /boot/initramfs-linux-fallback.img
     append earlyprintk rw root=/dev/vda1 rootwait rootfstype=ext4 LANG=en_US.UTF-8 console=ttyS0
 EOF
+
+cat << EOF | sudo tee qcow2/etc/systemd/network/default.network
+[Match]
+Name=en*
+
+[Network]
+DHCP=yes
+EOF
+sudo systemd-nspawn -D qcow2 systemctl enable systemd-networkd.service
 
 msg "Clean up..."
 msg2 "Clean up pacman package cache..."

--- a/startqemu.sh
+++ b/startqemu.sh
@@ -21,6 +21,7 @@ qemu-system-riscv64 \
     -machine virt \
     -smp 8 \
     -m 4G \
+    -netdev user,id=n0 -device virtio-net,netdev=n0 \
     -bios ./opensbi_fw_payload.bin \
     -device virtio-blk-device,drive=hd0 \
     -object rng-random,filename=/dev/urandom,id=rng0 \


### PR DESCRIPTION
- Enable networking by default as it's often useful.
- Use systemd-nspawn instead of arch-chroot because the latter is known to be fragile and often results in mounts not being cleaned up correctly and broken images.