### PR TITLE
fix(mkimg): early quit if nbd module is missing

### DIFF
--- a/mkimg
+++ b/mkimg
@@ -105,7 +105,7 @@ cp ./opensbi/build/platform/generic/firmware/fw_payload.bin opensbi_fw_payload.b
 
 msg "Create image file..."
 qemu-img create -f qcow2 "$filename" 10G
-sudo modprobe nbd max_part=16
+sudo modprobe nbd max_part=16 || exit 1
 sudo qemu-nbd -c /dev/nbd0 "$filename"
 
 sudo sfdisk /dev/nbd0 <<EOF


### PR DESCRIPTION
probably caused by an Syu without reboot