### PR TITLE
chore: Add missing devtools-riscv64 prerequisite to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Useful scripts for building and running Arch RISC-V Qcow image.
 * qemu-img
 * qemu-system-riscv
 * riscv64-linux-gnu-gcc
+* devtools-riscv64 ([AUR](https://aur.archlinux.org/packages/devtools-riscv64))
 
 ## Build Step
 


### PR DESCRIPTION
Needed [here](https://github.com/CoelacanthusHex/archriscv-scriptlet/blob/c81a4c8590738610dc08cd2b0eb850dc32e5d669/mkrootfs#L59).