### PR TITLE
mkimg: Optimize boot times & initramfs build times

### DIFF
--- a/mkimg
+++ b/mkimg
@@ -182,6 +182,35 @@ fi
 
 sudo systemd-nspawn -D mnt pacman \
     --noconfirm --needed \
+    -Syu mkinitcpio
+
+# This disables initramfs compression, however it also keeps kernel modules
+# compressed so the net difference to initramfs size is negligible.
+# This makes boot a lot faster, since now we don't need to decompress
+# the whole initramfs but only a few modules, which also can be decompressed
+# in parrallel.
+cat << EOF | sudo patch -p1
+diff -Naurp a/mnt/etc/mkinitcpio.conf b/mnt/etc/mkinitcpio.conf
+--- a/mnt/etc/mkinitcpio.conf   2024-03-18 16:25:46.597751709 +0200
++++ b/mnt/etc/mkinitcpio.conf   2024-03-18 16:26:34.783941328 +0200
+@@ -61,6 +61,7 @@ HOOKS=(base udev autodetect modconf kms
+ #COMPRESSION="xz"
+ #COMPRESSION="lzop"
+ #COMPRESSION="lz4"
++COMPRESSION=cat
+
+ # COMPRESSION_OPTIONS
+ # Additional options for the compressor
+@@ -70,4 +71,4 @@ HOOKS=(base udev autodetect modconf kms
+ # Decompress kernel modules during initramfs creation.
+ # Enable to speedup boot process, disable to save RAM
+ # during early userspace. Switch (yes/no).
+-#MODULES_DECOMPRESS="yes"
++MODULES_DECOMPRESS="no"
+EOF
+
+sudo systemd-nspawn -D mnt pacman \
+    --noconfirm --needed \
     -Syu $kernel linux-firmware
 
 sudo mkdir -p mnt/boot/extlinux


### PR DESCRIPTION
By default, mkinitcpio decompresses kernel modules into a temporary directory when building initramfs, then compresses the resulting initramfs fully as a single blob

This default behavior might have been faster on some beefy x86_64 CPU, and also in the past when firmware wasn't compressed, we didn't have ZSTD etc, but in modern RISC-V reality it slows things down big time, because now the kernel has to decompress the whole huge initramfs at once upon initial boot instead of separately decompressing individual modules/firmware blobs. It doesn't help that firmware is seemingly compressed twice...

This patch to the mkinitcpio config shaves around 30 seconds of boot time on QEMU on my machine, and around 20 seconds of boot time on RVVM. Results from real boards are welcome (But I've definitely seen they also suffer from this slow initramfs decompression issue).
Perhaps it is possible to patch the default Arch RISC-V mkinitcpio package config instead, but I guess this is a less invasive proposal for those who might be interested in optimizing boot time right now

I'd also like to see some way to omit `linux-firmware` from being installed in the resulting image, but I am not sure how to implement it properly or what arg syntax would be acceptable. Thx for any advice or help.