### PR TITLE
Fix startqemu.sh for new QEMU

### DIFF
--- a/startqemu.sh
+++ b/startqemu.sh
@@ -26,5 +26,5 @@ qemu-system-riscv64 \
     -device virtio-blk-device,drive=hd0 \
     -object rng-random,filename=/dev/urandom,id=rng0 \
     -device virtio-rng-device,rng=rng0 \
-    -drive file="$file",format=qcow2,id=hd0 \
+    -drive file="$file",format=qcow2,id=hd0,if=none \
     -monitor unix:/tmp/qemu-monitor,server,nowait


### PR DESCRIPTION
Latest QEMU (9.1.0 here) breaks here without this change:

```
Drive 'hd0' is already in use because it has been automatically connected to another device (did you need 'if=none' in the drive options?)
```