### PR TITLE
mkimg: fix systemd-firstboot

### DIFF
--- a/mkimg
+++ b/mkimg
@@ -77,7 +77,8 @@ parse-args() {
 toggle-systemd-firstboot() {
     msg2 "Toggle systemd-firstboot..."
     sudo rm -f mnt/etc/{machine-id,hostname,shadow}
-    sudo systemd-nspawn -D mnt systemctl enable systemd-firstboot.service
+    # Mask Arch filesystem's factory to avoid the removed shadow file being copied over
+    sudo ln -s /dev/null mnt/etc/tmpfiles.d/arch.conf
 }
 
 use-fixed-password() {


### PR DESCRIPTION
Arch's filesystem factory copies over the /etc/shadow file, technically overrides systemd-firstboot. Let's mask it for now. Bug report opened at https://gitlab.archlinux.org/archlinux/packaging/packages/filesystem/-/issues/13