### PR TITLE
mkrootfs: Disable pacman sandbox for now

### DIFF
--- a/mkrootfs
+++ b/mkrootfs
@@ -62,6 +62,9 @@ sudo pacstrap \
     ./rootfs \
     base
 
+msg "Disable sandbox to fix old kernels / userland emulation"
+sudo sed -E -i 's|#DisableSandbox|DisableSandbox|g' ./rootfs/etc/pacman.conf
+
 msg "Set default mirror to https://riscv.mirror.pkgbuild.com"
 sudo sed -E -i 's|#(Server = https://riscv\.mirror\.pkgbuild\.com/repo/\$repo)|\1|' ./rootfs/etc/pacman.d/mirrorlist
 


### PR DESCRIPTION
- Pacman now uses LandLock/Seccomp by default
- When running an older kernel (Possibly a device-specific kernel tree) or qemu-user, this fails: 
```
error: restricting filesystem access failed because Landlock is not supported by the kernel!
error: switching to sandbox user 'alpm' failed!
error: failed to synchronize all databases (failed to retrieve some files)
```
- Fixes mkimg on the resulting rootfs, as well as some other issues, sandbox may be re-enabled when qemu-user supports LandLock but is not really necessary for now