### PR TITLE
mkimg: Fix build, bump firmware versions, misc improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-archriscv-*.tar.*
-archriscv-*.qcow2
+archriscv*
+fw_payload.bin
 dracut-hook/
 rootfs/
 qcow2/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arch RISC-V Scriptlet
 
-Useful scripts for building and running Arch RISC-V Qcow image.
+Useful scripts for building and running Arch RISC-V QCOW2 / raw image.
 
 ## Prerequisite
 
@@ -8,7 +8,7 @@ Useful scripts for building and running Arch RISC-V Qcow image.
 * parted
 * git
 * qemu-img
-* qemu-system-riscv
+* qemu-system-riscv or rvvm ([AUR](https://aur.archlinux.org/packages/rvvm-git))
 * riscv64-linux-gnu-gcc
 * devtools-riscv64 ([AUR](https://aur.archlinux.org/packages/devtools-riscv64))
 
@@ -16,15 +16,17 @@ Useful scripts for building and running Arch RISC-V Qcow image.
 
 ```bash
 ./mkrootfs
-./mkimg
+./mkimg [image file]
 ```
 
 ## Start QEMU
-
-> [!IMPORTANT]
-> You must use fallback initrd first, and re-generate initramfs with `mkinitcpio -P` to use non-fallback version later.
 
 ```bash
 ./startqemu.sh [qcow image file]
 ```
 
+## Start RVVM
+
+```bash
+./startrvvm.sh [raw image file]
+```

--- a/mkimg
+++ b/mkimg
@@ -19,6 +19,7 @@ fstype='ext4'
 kernel='linux'
 kernel_suffix=''
 cmdline=''
+packages=
 
 uboot_version='v2025.01'
 opensbi_version='v1.6'
@@ -42,12 +43,13 @@ Create Arch RISC-V distro image.
     -t FSTYPE   specify rootfs filesystem type (default: ext4)
     -k KERNEL   specify kernel package name (default: linux)
     -c CMDLINE  append CMDLINE to kernel command line
+    -i PACKAGE  install additional packages (Like linux-firmware)
 EOF
 }
 
 parse-args() {
     local OPTIND=1
-    while getopts 'hvfdp:r:l:t:k:c:' opt; do
+    while getopts 'hvfdp:r:l:t:k:c:i:' opt; do
       case $opt in
         h)  show_help
             exit 0
@@ -70,6 +72,8 @@ parse-args() {
         k)  kernel=$OPTARG
             ;;
         c)  cmdline=$OPTARG
+            ;;
+        i)  packages="$packages $OPTARG"
             ;;
         *)  show_help >&2
             exit 1
@@ -200,10 +204,10 @@ sudo bsdtar $verbose_arg -kpxf "../$rootfs"
 popd
 
 #
-# Install kernel & firmware
+# Install kernel & user-requested packages
 #
 
-msg "Install kernel package..."
+msg "Install kernel & packages..."
 
 if [[ $kernel != linux ]]
 then
@@ -213,7 +217,7 @@ fi
 
 sudo systemd-nspawn -D mnt pacman \
     --noconfirm --needed \
-    -Syu $kernel linux-firmware
+    -Syu $kernel $packages
 
 #
 # Create extlinux boot entries for U-Boot

--- a/mkimg
+++ b/mkimg
@@ -144,7 +144,7 @@ fi
 # Create QCOW2 or RAW image of requested size (16G by default)
 #
 
-if [ "$filename" == *.qcow2 ]
+if [[ "$filename" == *.qcow2 ]]
 then
     msg "Create QCOW2 image..."
     qemu-img create -f qcow2 "$filename" "$imgsize"

--- a/mkimg
+++ b/mkimg
@@ -55,7 +55,7 @@ parse-args() {
             exit 0
             ;;
         v)  verbose=$((verbose+1))
-            verbose_arg="--verbose"
+            verbose_arg='--verbose'
             ;;
         f)  use_fixed_password=1
             ;;
@@ -102,26 +102,17 @@ parse-args "$@"
 # Build firmware (OpenSBI + U-Boot) if needed
 #
 
-if [[ $build_firmware == 1 ]]
+if [ $build_firmware == 1 ] && [ ! -f './fw_payload.bin' ]
 then
     msg "Building U-Boot..."
-    if [[ -d u-boot ]]; then
-        pushd u-boot
-        git checkout HEAD -- ':(top)'
-        git fetch origin
-        git checkout $uboot_version
-        popd
-    else
-        git clone --filter=blob:none -b $uboot_version https://github.com/u-boot/u-boot.git
-    fi
-    pushd u-boot
-
+    git clone --filter=blob:none -b $uboot_version https://github.com/u-boot/u-boot.git
+    pushd u-boot >/dev/null
     make -j$(nproc) \
         CROSS_COMPILE=riscv64-linux-gnu- \
         qemu-riscv64_smode_defconfig
     if [[ "$fstype" == "btrfs" ]]
     then
-        msg "Enabling BTRFS support in U-Boot"
+        msg2 "Enabling BTRFS support in U-Boot"
         ./scripts/config -e CMD_BTRFS -e FS_BTRFS
     fi
     make -j$(nproc) \
@@ -129,19 +120,11 @@ then
         olddefconfig
     make -j$(nproc) \
         CROSS_COMPILE=riscv64-linux-gnu-
-    popd
+    popd >/dev/null
 
     msg "Building OpenSBI..."
-    if [[ -d opensbi ]]; then
-        pushd opensbi
-        git checkout HEAD -- ':(top)'
-        git fetch origin
-        git checkout $opensbi_version
-        popd
-    else
-        git clone --filter=blob:none -b $opensbi_version https://github.com/riscv-software-src/opensbi
-    fi
-    pushd opensbi
+    git clone --filter=blob:none -b $opensbi_version https://github.com/riscv-software-src/opensbi
+    pushd opensbi >/dev/null
 
     # If user set it, OpenSBI will fail to build.
     unset PYTHONSAFEPATH
@@ -150,16 +133,18 @@ then
         CROSS_COMPILE=riscv64-linux-gnu- \
         PLATFORM=generic \
         FW_PAYLOAD_PATH=../u-boot/u-boot.bin
-    popd
+    popd >/dev/null
 
     cp ./opensbi/build/platform/generic/firmware/fw_payload.bin ./
+    rm -rf ./u-boot
+    rm -rf ./opensbi
 fi
 
 #
 # Create QCOW2 or RAW image of requested size (16G by default)
 #
 
-if [[ "$filename" == *.qcow2 ]]
+if [ "$filename" == *.qcow2 ]
 then
     msg "Create QCOW2 image..."
     qemu-img create -f qcow2 "$filename" "$imgsize"
@@ -168,8 +153,13 @@ then
     sudo qemu-nbd -c /dev/nbd0 "$filename"
     loopdev=/dev/nbd0
 else
-    msg "Create raw image..."
-    fallocate "$filename" -l "$imgsize"
+    if truncate "$filename" -s 0 2>/dev/null
+    then
+        msg "Create raw image..."
+        truncate "$filename" -s "$imgsize"
+    else
+        msg "Assuming we are targeting a raw block device"
+    fi
     loopdev=$(sudo losetup --show -P -f "$filename")
 fi
 
@@ -179,7 +169,7 @@ fi
 
 msg "Partitioning..."
 # FIXME: otherwise NBD device is not ready
-sleep 1s
+sleep 3s
 sudo parted "$loopdev" mklabel gpt mkpart "" "$fstype" 0% 100%
 
 sudo partprobe "$loopdev"
@@ -199,9 +189,36 @@ uuid=$(sudo findmnt mnt -o UUID -n)
 
 msg "Extract rootfs..."
 
-pushd mnt
+pushd mnt >/dev/null
 sudo bsdtar $verbose_arg -kpxf "../$rootfs"
-popd
+popd >/dev/null
+
+#
+# Disable module autodetect filtering. This fixes boot on wildly different hardware from image build host.
+#
+# Disable initramfs compression. The net effect is that, on slow CPUs without SIMD-accelerated zstd,
+# initramfs boots faster (Plus the modules decompression now runs in SMP).
+#
+
+msg "Fixup mkinitcpio"
+sudo mkdir -p mnt/etc/mkinitcpio.d
+cat << EOF | sudo tee mnt/etc/mkinitcpio.d/linux.preset >/dev/null
+# mkinitcpio preset file for the 'linux' package
+ALL_kver="/boot/vmlinuz-linux"
+PRESETS=('default')
+default_image="/boot/initramfs-linux.img"
+fallback_image="/boot/initramfs-linux-fallback.img"
+fallback_options="-S autodetect"
+EOF
+cat << EOF | sudo tee mnt/etc/mkinitcpio.conf >/dev/null
+# vim:set ft=sh:
+MODULES=()
+BINARIES=()
+FILES=()
+HOOKS=(base udev microcode modconf block filesystems fsck)
+COMPRESSION="cat"
+MODULES_DECOMPRESS="no"
+EOF
 
 #
 # Install kernel & user-requested packages
@@ -209,10 +226,10 @@ popd
 
 msg "Install kernel & packages..."
 
-if [[ $kernel != linux ]]
+if [ "$kernel" != 'linux' ]
 then
     kernel_suffix="${kernel#linux}"
-    echo -e "[unsupported]\nInclude = /etc/pacman.d/mirrorlist" | sudo tee -a mnt/etc/pacman.conf
+    echo -e "[unsupported]\nInclude = /etc/pacman.d/mirrorlist" | sudo tee -a mnt/etc/pacman.conf >/dev/null
 fi
 
 sudo systemd-nspawn -D mnt pacman \
@@ -224,29 +241,23 @@ sudo systemd-nspawn -D mnt pacman \
 #
 
 sudo mkdir -p mnt/boot/extlinux
-cat << EOF | sudo tee mnt/boot/extlinux/extlinux.conf
+cat << EOF | sudo tee mnt/boot/extlinux/extlinux.conf >/dev/null
 menu title Arch RISC-V Boot Menu
 timeout 100
-default linux-fallback
+default linux
 
 label linux
     menu label Linux linux
     kernel /boot/vmlinuz-linux$kernel_suffix
     initrd /boot/initramfs-linux$kernel_suffix.img
-    append earlyprintk rw root=UUID=$uuid rootwait console=ttyS0,115200 $cmdline
-
-label linux-fallback
-    menu label Linux linux (fallback initramfs)
-    kernel /boot/vmlinuz-linux$kernel_suffix
-    initrd /boot/initramfs-linux$kernel_suffix-fallback.img
-    append earlyprintk rw root=UUID=$uuid rootwait console=ttyS0,115200 $cmdline
+    append rw root=UUID=$uuid rootwait $cmdline
 EOF
 
 #
 # Enable DHCP networking by default
 #
 
-cat << EOF | sudo tee mnt/etc/systemd/network/default.network
+cat << EOF | sudo tee mnt/etc/systemd/network/default.network >/dev/null
 [Match]
 Name=en*
 
@@ -269,6 +280,7 @@ yes y | sudo pacman \
 
 msg2 "Unmount and sync..."
 sudo umount mnt
+sudo rmdir mnt
 if [[ $filename == *.qcow2 ]]
 then
     sudo qemu-nbd -d "$loopdev"

--- a/mkimg
+++ b/mkimg
@@ -7,18 +7,21 @@
 . /usr/share/makepkg/util.sh
 colorize
 
+set -e
+
 verbose=0
+verbose_arg=
 use_fixed_password=0
 build_firmware=1
-varbose_arg=
 rootfs="archriscv-$(date --rfc-3339=date).tar.zst"
-fstype=ext4
-kernel=linux
-kernel_suffix=""
-cmdline=""
+imgsize='16G'
+fstype='ext4'
+kernel='linux'
+kernel_suffix=''
+cmdline=''
 
-uboot_version=v2023.10
-opensbi_version=v1.3.1
+uboot_version='v2025.01'
+opensbi_version='v1.6'
 
 show_help() {
 cat << EOF
@@ -30,26 +33,27 @@ Create Arch RISC-V distro image.
                 unless the extension is qcow2, implies raw disk format
 
     -h          display this help and exit
+    -v          verbose mode
     -f          use fixed password instead of using systemd-firstboot to ask
     -d          only build the disk image and omit building OpenSBI/U-Boot
     -p PASSWORD set root password to PASSWORD instead of passwd in rootfs
     -r ROOTFS   specify rootfs file name
+    -l IMGSIZE  specify image size, e.g. 10G
     -t FSTYPE   specify rootfs filesystem type (default: ext4)
     -k KERNEL   specify kernel package name (default: linux)
     -c CMDLINE  append CMDLINE to kernel command line
-    -v          verbose mode
 EOF
 }
 
 parse-args() {
     local OPTIND=1
-    while getopts 'hvfdr:t:p:k:c:' opt; do
+    while getopts 'hvfdp:r:l:t:k:c:' opt; do
       case $opt in
         h)  show_help
             exit 0
             ;;
         v)  verbose=$((verbose+1))
-            varbose_arg="--verbose"
+            verbose_arg="--verbose"
             ;;
         f)  use_fixed_password=1
             ;;
@@ -58,6 +62,8 @@ parse-args() {
         p)  password=$OPTARG
             ;;
         r)  rootfs=$OPTARG
+            ;;
+        l)  imgsize=$OPTARG
             ;;
         t)  fstype=$OPTARG
             ;;
@@ -88,10 +94,13 @@ use-fixed-password() {
 
 parse-args "$@"
 
-if [ $build_firmware == 1 ]
+#
+# Build firmware (OpenSBI + U-Boot) if needed
+#
+
+if [[ $build_firmware == 1 ]]
 then
     msg "Building U-Boot..."
-
     if [[ -d u-boot ]]; then
         pushd u-boot
         git checkout HEAD -- ':(top)'
@@ -103,19 +112,22 @@ then
     fi
     pushd u-boot
 
-    make \
+    make -j$(nproc) \
         CROSS_COMPILE=riscv64-linux-gnu- \
         qemu-riscv64_smode_defconfig
-    ./scripts/config \
-        -e CMD_BTRFS -e FS_BTRFS
-    make \
+    if [[ "$fstype" == "btrfs" ]]
+    then
+        msg "Enabling BTRFS support in U-Boot"
+        ./scripts/config -e CMD_BTRFS -e FS_BTRFS
+    fi
+    make -j$(nproc) \
         CROSS_COMPILE=riscv64-linux-gnu- \
         olddefconfig
-    make CROSS_COMPILE=riscv64-linux-gnu-
+    make -j$(nproc) \
+        CROSS_COMPILE=riscv64-linux-gnu-
     popd
 
     msg "Building OpenSBI..."
-
     if [[ -d opensbi ]]; then
         pushd opensbi
         git checkout HEAD -- ':(top)'
@@ -127,31 +139,39 @@ then
     fi
     pushd opensbi
 
-    # If user set it, OpenSBI will failed to build.
+    # If user set it, OpenSBI will fail to build.
     unset PYTHONSAFEPATH
 
-    make \
+    make -j$(nproc) \
         CROSS_COMPILE=riscv64-linux-gnu- \
         PLATFORM=generic \
         FW_PAYLOAD_PATH=../u-boot/u-boot.bin
     popd
 
-    cp ./opensbi/build/platform/generic/firmware/fw_payload.bin opensbi_fw_payload.bin
+    cp ./opensbi/build/platform/generic/firmware/fw_payload.bin ./
 fi
 
-if [[ $filename == *.qcow2 ]]
+#
+# Create QCOW2 or RAW image of requested size (16G by default)
+#
+
+if [[ "$filename" == *.qcow2 ]]
 then
     msg "Create QCOW2 image..."
-    qemu-img create -f qcow2 "$filename" 10G
+    qemu-img create -f qcow2 "$filename" "$imgsize"
     sudo modprobe nbd max_part=16 || exit 1
     # Possible NBD device collision?
     sudo qemu-nbd -c /dev/nbd0 "$filename"
     loopdev=/dev/nbd0
 else
     msg "Create raw image..."
-    fallocate "$filename" -l 10G
+    fallocate "$filename" -l "$imgsize"
     loopdev=$(sudo losetup --show -P -f "$filename")
 fi
+
+#
+# Partition the image into a single rootfs
+#
 
 msg "Partitioning..."
 # FIXME: otherwise NBD device is not ready
@@ -169,11 +189,19 @@ sudo chown root:root mnt
 
 uuid=$(sudo findmnt mnt -o UUID -n)
 
+#
+# Extract existing distro rootfs tarfile
+#
+
 msg "Extract rootfs..."
 
 pushd mnt
-sudo bsdtar $varbose_arg -kpxf "../$rootfs"
+sudo bsdtar $verbose_arg -kpxf "../$rootfs"
 popd
+
+#
+# Install kernel & firmware
+#
 
 msg "Install kernel package..."
 
@@ -186,6 +214,10 @@ fi
 sudo systemd-nspawn -D mnt pacman \
     --noconfirm --needed \
     -Syu $kernel linux-firmware
+
+#
+# Create extlinux boot entries for U-Boot
+#
 
 sudo mkdir -p mnt/boot/extlinux
 cat << EOF | sudo tee mnt/boot/extlinux/extlinux.conf
@@ -206,6 +238,10 @@ label linux-fallback
     append earlyprintk rw root=UUID=$uuid rootwait console=ttyS0,115200 $cmdline
 EOF
 
+#
+# Enable DHCP networking by default
+#
+
 cat << EOF | sudo tee mnt/etc/systemd/network/default.network
 [Match]
 Name=en*
@@ -214,6 +250,10 @@ Name=en*
 DHCP=yes
 EOF
 sudo systemd-nspawn -D mnt systemctl enable systemd-networkd.service
+
+#
+# Graceful completion
+#
 
 msg "Clean up..."
 msg2 "Clean up pacman package cache..."

--- a/mkrootfs
+++ b/mkrootfs
@@ -65,6 +65,28 @@ sudo pacstrap \
 msg "Disable sandbox to fix old kernels / userland emulation"
 sudo sed -E -i 's|#DisableSandbox|DisableSandbox|g' ./rootfs/etc/pacman.conf
 
+msg "Enable fallback initramfs"
+sudo mkdir -p ./rootfs/etc/mkinitcpio.d
+cat << EOF | sudo tee ./rootfs/etc/mkinitcpio.d/linux.preset >/dev/null
+# mkinitcpio preset file for the 'linux' package
+
+#ALL_config="/etc/mkinitcpio.conf"
+ALL_kver="/boot/vmlinuz-linux"
+#ALL_kerneldest="/boot/vmlinuz-linux"
+
+PRESETS=('default' 'fallback')
+
+#default_config="/etc/mkinitcpio.conf"
+default_image="/boot/initramfs-linux.img"
+#default_uki="/efi/EFI/Linux/arch-linux.efi"
+#default_options="--splash /usr/share/systemd/bootctl/splash-arch.bmp"
+
+#fallback_config="/etc/mkinitcpio.conf"
+fallback_image="/boot/initramfs-linux-fallback.img"
+#fallback_uki="/efi/EFI/Linux/arch-linux-fallback.efi"
+fallback_options="-S autodetect"
+EOF
+
 msg "Set default mirror to https://riscv.mirror.pkgbuild.com"
 sudo sed -E -i 's|#(Server = https://riscv\.mirror\.pkgbuild\.com/repo/\$repo)|\1|' ./rootfs/etc/pacman.d/mirrorlist
 

--- a/mkrootfs
+++ b/mkrootfs
@@ -62,6 +62,9 @@ sudo pacstrap \
     ./rootfs \
     base
 
+msg "Disable sandbox to fix old kernels / userland emulation"
+sudo sed -E -i 's|#DisableSandbox|DisableSandbox|g' ./rootfs/etc/pacman.conf
+
 msg "Set default mirror to https://riscv.mirror.pkgbuild.com"
 sudo sed -E -i 's|#(Server = https://riscv\.mirror\.pkgbuild\.com/repo/\$repo)|\1|' ./rootfs/etc/pacman.d/mirrorlist
 

--- a/mkrootfs
+++ b/mkrootfs
@@ -72,28 +72,6 @@ sudo sed -E -i 's|#Color|Color|' ./rootfs/etc/pacman.conf
 sudo sed -E -i 's|#DisableSandbox|DisableSandbox|g' ./rootfs/etc/pacman.conf
 sudo sed -E -i 's|CheckSpace|#CheckSpace|' ./rootfs/etc/pacman.conf
 
-msg "Enable fallback initramfs"
-sudo mkdir -p ./rootfs/etc/mkinitcpio.d
-cat << EOF | sudo tee ./rootfs/etc/mkinitcpio.d/linux.preset >/dev/null
-# mkinitcpio preset file for the 'linux' package
-
-#ALL_config="/etc/mkinitcpio.conf"
-ALL_kver="/boot/vmlinuz-linux"
-#ALL_kerneldest="/boot/vmlinuz-linux"
-
-PRESETS=('default' 'fallback')
-
-#default_config="/etc/mkinitcpio.conf"
-default_image="/boot/initramfs-linux.img"
-#default_uki="/efi/EFI/Linux/arch-linux.efi"
-#default_options="--splash /usr/share/systemd/bootctl/splash-arch.bmp"
-
-#fallback_config="/etc/mkinitcpio.conf"
-fallback_image="/boot/initramfs-linux-fallback.img"
-#fallback_uki="/efi/EFI/Linux/arch-linux-fallback.efi"
-fallback_options="-S autodetect"
-EOF
-
 msg "Set default mirror to https://riscv.mirror.pkgbuild.com"
 sudo sed -E -i 's|#(Server = https://riscv\.mirror\.pkgbuild\.com/repo/\$repo)|\1|' ./rootfs/etc/pacman.d/mirrorlist
 

--- a/mkrootfs
+++ b/mkrootfs
@@ -10,10 +10,11 @@ colorize
 verbose=0
 verbose_arg=
 password='archriscv'
+packages=
 
 show_help() {
 cat << EOF
-Usage: ${0##*/} [-hv] [-p PASSWORD] [FILENAME]
+Usage: ${0##*/} [-hv] [-p PASSWORD] [-i PACKAGE] [FILENAME]
 Create Arch RISC-V rootfs.
 
     FILENAME    generated rootfs file name, use the archive suffix to decide
@@ -21,14 +22,15 @@ Create Arch RISC-V rootfs.
                 default: 'archriscv-$(date --rfc-3339=date).tar.zst'
 
     -h          display this help and exit
-    -p PASSWORD set root password to PASSWORD instead of archriscv
     -v          verbose mode
+    -p PASSWORD set root password to PASSWORD instead of archriscv
+    -i PACKAGE  install additional packages
 EOF
 }
 
 parse-args() {
     local OPTIND=1
-    while getopts 'hvp:' opt; do
+    while getopts 'hvp:i:' opt; do
       case $opt in
         h)
             show_help
@@ -38,6 +40,8 @@ parse-args() {
             verbose_arg="--verbose"
             ;;
         p)  password=$OPTARG
+            ;;
+        i)  packages="$packages $OPTARG"
             ;;
         *)
             show_help >&2
@@ -60,10 +64,13 @@ sudo pacstrap \
     -M \
     -K \
     ./rootfs \
-    base
+    base $packages
 
-msg "Disable sandbox to fix old kernels / userland emulation"
+msg "Tune pacman.conf (Disable sandbox & CheckSpace, Color)"
+sudo sed -E -i 's|#Color|Color|' ./rootfs/etc/pacman.conf
+# Pacman sandbox fails under qemu-user & old kernels, similar issues with CheckSpace
 sudo sed -E -i 's|#DisableSandbox|DisableSandbox|g' ./rootfs/etc/pacman.conf
+sudo sed -E -i 's|CheckSpace|#CheckSpace|' ./rootfs/etc/pacman.conf
 
 msg "Enable fallback initramfs"
 sudo mkdir -p ./rootfs/etc/mkinitcpio.d

--- a/startqemu.sh
+++ b/startqemu.sh
@@ -22,7 +22,7 @@ qemu-system-riscv64 \
     -smp 8 \
     -m 4G \
     -netdev user,id=n0 -device virtio-net,netdev=n0 \
-    -bios ./opensbi_fw_payload.bin \
+    -bios ./fw_payload.bin \
     -device virtio-blk-device,drive=hd0 \
     -object rng-random,filename=/dev/urandom,id=rng0 \
     -device virtio-rng-device,rng=rng0 \

--- a/startrvvm.sh
+++ b/startrvvm.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/bash
+#
+# SPDX-FileCopyrightText: 2022 Celeste Liu <coelacanthus@outlook.com>
+# SPDX-FileCopyrightText: 2025 Kurchatova Eva <lekkit@at.encryp.ch>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Install rvvm-git from AUR
+
+# shellcheck disable=1091
+. /usr/share/makepkg/util.sh
+colorize
+
+parse-args() {
+    local OPTIND=1
+    shift "$(( OPTIND-1 ))"
+    file=${1:-archriscv.img}
+}
+
+parse-args "$@"
+
+if [ ! -f './fw_payload.bin' ] || [ ! -f "$file" ]
+then
+msg "Building boot images"
+./mkrootfs -i nano -i htop -i fastfestch
+./mkimg -c "audit=0 loglevel=6 console=ttyS0 console=tty0" -l 64G "$file"
+fi
+
+msg "Starting RVVM"
+rvvm \
+    -smp 8 \
+    -m 4G \
+    -res 1280x720 \
+    -portfwd 2022=22 \
+    -jitcache 128M \
+    -bios ./fw_payload.bin \
+    -nvme "$file"


### PR DESCRIPTION
- Fix `mkimg` build due to pacman sandbox failure in qemu-user
- Fix fallback initramfs generation which is required for proper boot at least once
- Bump U-Boot to v2025.01, OpenSBI to v1.6
- Implement `-l 16G`  argument to `mkimg` to specify resulting image size instead of hardcoded 10G size

Now this can build fully mainline firmware & images which can run on RVVM out of the box too:

<img width="683" height="528" alt="image" src="https://github.com/user-attachments/assets/590b00de-2213-4474-bdb7-5a673c64feeb" />
